### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,19 @@ We welcome contributions from the community! Whether you're fixing bugs, adding 
 
 <!-- Ultralytics contributors -->
 
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors">
+<a href="https://github.com/ultralytics/tinder/graphs/contributors">
 <img width="100%" src="https://github.com/ultralytics/assets/raw/main/im/image-contributors.png" alt="Ultralytics open-source contributors"></a>
 
 # ©️ License
 
 Ultralytics is excited to offer two different licensing options to meet your needs:
 
-- **AGPL-3.0 License**: Perfect for students and hobbyists, this [OSI-approved](https://opensource.org/license) open-source license encourages collaborative learning and knowledge sharing. Please refer to the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for detailed terms.
+- **AGPL-3.0 License**: Perfect for students and hobbyists, this [OSI-approved](https://opensource.org/license/agpl-v3) open-source license encourages collaborative learning and knowledge sharing. Please refer to the [LICENSE](https://github.com/ultralytics/tinder/blob/main/LICENSE) file for detailed terms.
 - **Enterprise License**: Ideal for commercial use, this license allows for the integration of Ultralytics software and AI models into commercial products without the open-source requirements of AGPL-3.0. For use cases that involve commercial applications, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 # 📬 Contact Us
 
-For bug reports, feature requests, and contributions, head to [GitHub Issues](https://github.com/ultralytics/velocity/issues). For questions and discussions about this project and other Ultralytics endeavors, join us on [Discord](https://discord.com/invite/ultralytics)!
+For bug reports, feature requests, and contributions, head to [GitHub Issues](https://github.com/ultralytics/tinder/issues). For questions and discussions about this project and other Ultralytics endeavors, join us on [Discord](https://discord.com/invite/ultralytics)!
 
 <br>
 <div align="center">


### PR DESCRIPTION
## Summary
- retargets repository-specific README links to ultralytics/tinder
- points the AGPL reference at the exact OSI license page and local LICENSE file
- preserves existing README badges and linked assets

## Validation
- git diff --check
- lychee README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR cleans up `README.md` links so they correctly point to the `ultralytics/tinder` repository and updated license references.

### 📊 Key Changes
- 🔗 Updated the contributors section link to point to the correct [tinder contributors page](https://github.com/ultralytics/tinder/graphs/contributors) instead of another Ultralytics repo.
- 📄 Fixed the AGPL-3.0 license reference to use the proper [AGPL v3 OSI page](https://opensource.org/license/agpl-v3).
- 📘 Corrected the README license file link so it now points to the [tinder LICENSE file](https://github.com/ultralytics/tinder/blob/main/LICENSE).
- 🐛 Updated the bug report and feature request link to the correct [tinder issues page](https://github.com/ultralytics/tinder/issues) instead of the unrelated `velocity` repo.

### 🎯 Purpose & Impact
- ✅ Improves documentation accuracy by ensuring users land in the right repository pages.
- 🚀 Makes it easier for contributors to find the correct issues, license, and contributor information.
- 🧭 Reduces confusion caused by outdated or mismatched links copied from other projects.
- 📚 Helps present the `ultralytics/tinder` project more professionally and consistently for both new users and contributors.